### PR TITLE
Add support for SubClassOf + Custom Prefixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ merweb -f examples/diagram.txt \
   -s shapes.jsonld \
   -b "sc=https://w3id.org/idlab/ns/supply-chain/#" \
   -v "sc=https://w3id.org/idlab/ns/supply-chain/#" \
+  -p "swrl=http://www.w3.org/2003/11/swrl#;owl=http://www.w3.org/2002/07/owl#"
   -c vocab.jsonld
 ```
 
@@ -29,12 +30,17 @@ Below you can find a table of these annotations.
 
 | Annotation | Description | Shape | Vocabulary | Existing or new annotation |
 | ---------- | ----------- | ----- | ---------- | --------------- |
-| `@type` | The type of as class | Object of `sh:targetNode` | A `rdfs:Class` | New |
-| `@extraTypes` | The extra types of as class | Object of `sh:property` with `rdf:type` as `sh:path` | A `rdfs:Class` | New |
+| `@type` | The type of a class | Object of `sh:targetNode` | A `rdfs:Class` | New |
+| `@superTypes` | The super-types of a class | N/A | Object(s) of `rdfs:subClassOf` | New |
+| `@extraTypes` | The extra types of a class | Object of `sh:property` with `rdf:type` as `sh:path` | A `rdfs:Class` | New |
 | `@label` | The label of a class or property | N/A | Object of `rdfs:label` | New  |
 | `@comment` | The comment of a class or property | N/A | Object of `rdfs:comment` | New |
 | Cardinality on a class attribute| The cardinality of datatype property | Objects of `sh:minCount` and `sh:maxCount` | N/A | New |
 | [Cardinality on a relationship between two classes](https://mermaid-js.github.io/mermaid/#/classDiagram?id=cardinality-multiplicity-on-relations) | The cardinality of object property | Objects of `sh:minCount` and `sh:maxCount` | N/A | Existing |
+
+Please note that the annotations `@type`, `@superTypes`, and `@extraTypes` assume a strict ordering: 
+`@type` should always be declared before `@superTypes` and `@extraTypes` are declared. The internal ordering of the latter two can be arbitrary.
+
 
 ## Remove annotations from diagrams
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ merweb -f examples/diagram.txt \
   -s shapes.jsonld \
   -b "sc=https://w3id.org/idlab/ns/supply-chain/#" \
   -v "sc=https://w3id.org/idlab/ns/supply-chain/#" \
-  -p "swrl=http://www.w3.org/2003/11/swrl#;owl=http://www.w3.org/2002/07/owl#"
+  -p "swrl=http://www.w3.org/2003/11/swrl#;owl=http://www.w3.org/2002/07/owl#" \
+  -c vocab.jsonld
+```
+or
+```bash
+merweb -f examples/diagram_with_supertypes.txt \
+  -s shapes.jsonld \
+  -b "ex=https://example.org/examples#" \
+  -v "ex=https://example.org/examples#" \
+  -p "swrl=http://www.w3.org/2003/11/swrl#;owl=http://www.w3.org/2002/07/owl#" \
   -c vocab.jsonld
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,7 @@ async function main() {
     .option('-b, --shapes-base-iri <iri>', 'Base IRI of the shapes', 'ex=http://example.com/')
     .option('-c, --custom-output <path>', 'Base IRI of the shapes',)
     .option('-v, --custom-base-iri <iri>', 'Base IRI of custom vocabulary',)
+    .option('-p, --custom-prefixes <iri>', 'Prefixes mapped to IRIs',)
     .option('-r, --remove-annotations', 'Remove annotations of diagram. Result is written to stdout',);
 
   program.parse(process.argv);
@@ -44,6 +45,14 @@ async function main() {
       prefix: options.customBaseIri.split('=')[0],
       iri: options.customBaseIri.split('=')[1]
     }
+  }
+
+  if (options.customPrefixes) {
+    const prefixes = options.customPrefixes.split(";")
+    opt.customPrefixes = {}
+    prefixes.forEach(prefix => {
+      opt.customPrefixes[prefix.split("=")[0]] = prefix.split("=")[1]
+    });
   }
 
   const {shapes, customVocab} = parseDiagram(diagram, opt);

--- a/examples/diagram.txt
+++ b/examples/diagram.txt
@@ -73,7 +73,6 @@ classDiagram
 
   class CustomerItemOption {
     @type sc:CustomerItemOption
-    @superTypes schema:Thing owl:Thing
     @label Customer Item Option
     @comment This represents a combination of a customer and an item.
 
@@ -115,7 +114,6 @@ classDiagram
 
   class LocationToLocation {
     @type sc:LocationToLocation
-    @superTypes schema:Thing owl:Thing
     @label Location to Location
     @comment This represents information about transporting items from one location to another.
 
@@ -131,7 +129,6 @@ classDiagram
 
   class SupplierItemLocationOption {
     @type sc:SupplierItemLocationOption
-    @superTypes schema:Thing owl:Thing
     @label Supplier Item Location Option
     @comment This represents a combination of a supplier and an item at a specification location.
 
@@ -149,7 +146,6 @@ classDiagram
 
   class LocationItemOption {
     @type sc:LocationItemOption
-    @superTypes schema:Thing owl:Thing
     @label Location Item Option
     @comment This represents a combination of a location and an item.
 

--- a/examples/diagram.txt
+++ b/examples/diagram.txt
@@ -73,6 +73,7 @@ classDiagram
 
   class CustomerItemOption {
     @type sc:CustomerItemOption
+    @superTypes schema:Thing owl:Thing
     @label Customer Item Option
     @comment This represents a combination of a customer and an item.
 
@@ -114,6 +115,7 @@ classDiagram
 
   class LocationToLocation {
     @type sc:LocationToLocation
+    @superTypes schema:Thing owl:Thing
     @label Location to Location
     @comment This represents information about transporting items from one location to another.
 
@@ -129,6 +131,7 @@ classDiagram
 
   class SupplierItemLocationOption {
     @type sc:SupplierItemLocationOption
+    @superTypes schema:Thing owl:Thing
     @label Supplier Item Location Option
     @comment This represents a combination of a supplier and an item at a specification location.
 
@@ -146,6 +149,7 @@ classDiagram
 
   class LocationItemOption {
     @type sc:LocationItemOption
+    @superTypes schema:Thing owl:Thing
     @label Location Item Option
     @comment This represents a combination of a location and an item.
 

--- a/examples/diagram_with_supertypes.txt
+++ b/examples/diagram_with_supertypes.txt
@@ -1,0 +1,22 @@
+classDiagram
+  direction BT
+
+  class Olympian {
+    @type ex:Olympian
+    @superTypes ex:Deity owl:Thing
+  }
+
+  class Titan {
+    @type ex:Titan
+    @superTypes ex:Deity owl:Thing
+  }
+
+  class Human {
+    @type ex:Human
+    @superTypes ex:Mortal owl:Thing
+  }
+
+  class Hero {
+    @type ex:Hero
+    @superTypes ex:Human
+  }

--- a/index.js
+++ b/index.js
@@ -108,34 +108,27 @@ function parseMembers(options) {
       shape.targetClass = {'@id': split[1]};
       idToType[id] = split[1];
 
-      // able to define extra classes beyond 'type' to create class hierarchy
-      let subClasses = [];
-      if (split.length > 2) {
-        for(let i = 2, size = split.length; i < size ; i++){
-          subClasses.push(split[i]);
-        }
-      }
-
       if (customBaseIri && split[1].startsWith(customBaseIri.prefix + ':')) {
         latestCustomVocabElementId = split[1];
-        if (subClasses.length === 0) { // add default subclassOf definition
           customVocab.push({
             '@id': latestCustomVocabElementId,
             '@type': 'Class',
             'subClassOf': {'@id': 'owl:Thing'}
           });
-        } else { // add custom subClassOf definitions
-          let scListOfMaps = []
-          subClasses.forEach(sc => {
-            scListOfMaps.push({'@id': sc})
-          })
-          customVocab.push({
-            '@id': latestCustomVocabElementId,
-            '@type': 'Class',
-            'subClassOf': {'@list': scListOfMaps}
-          });
-        }
       }
+    } else if (split[0] === '@superTypes') { // always assumes @type has already been defined
+      // able to define extra classes beyond 'type' to create class hierarchy
+      let subClasses = [];
+      for (let i = 1, size = split.length; i < size ; i++) {
+        subClasses.push(split[i]);
+      }
+        
+      customVocab.pop() // remove previous default subClass definition
+      customVocab.push({
+        '@id': latestCustomVocabElementId,
+        '@type': 'Class',
+        'subClassOf': {'@list': subClasses.map(sc => {return {'@id': sc}})}
+      });
     } else if (split[0] === '@extraTypes') {
       const types = member.replace('@extraTypes ', '').split(' ');
       if (!shape.property) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import mermaid from 'mermaid';
 
 function main(input, options) {
-  const {shapesBaseIri, customBaseIri} = options;
+  const {shapesBaseIri, customBaseIri, customPrefixes} = options;
   const idToType = {};
   const result = mermaid.parse(input).parser.yy;
   const classes = result.getClasses();
@@ -65,6 +65,9 @@ function main(input, options) {
   };
 
   finalShapes['@context'][shapesBaseIri.prefix] = shapesBaseIri.iri;
+  Object.keys(customPrefixes).forEach(prefix => {
+    finalShapes['@context'][prefix] = customPrefixes[prefix]
+  });
 
   if (customBaseIri) {
     finalShapes['@context'][customBaseIri.prefix] = customBaseIri.iri;
@@ -79,6 +82,9 @@ function main(input, options) {
     };
 
     finalCustomVocab['@context'][customBaseIri.prefix] = customBaseIri.iri;
+    Object.keys(customPrefixes).forEach(prefix => {
+      finalCustomVocab['@context'][prefix] = customPrefixes[prefix]
+    });
 
     return {shapes: finalShapes, customVocab: finalCustomVocab};
   } else {

--- a/index.js
+++ b/index.js
@@ -65,9 +65,11 @@ function main(input, options) {
   };
 
   finalShapes['@context'][shapesBaseIri.prefix] = shapesBaseIri.iri;
-  Object.keys(customPrefixes).forEach(prefix => {
-    finalShapes['@context'][prefix] = customPrefixes[prefix]
-  });
+  if (customPrefixes) {
+    Object.keys(customPrefixes).forEach(prefix => {
+      finalShapes['@context'][prefix] = customPrefixes[prefix]
+    });
+  }
 
   if (customBaseIri) {
     finalShapes['@context'][customBaseIri.prefix] = customBaseIri.iri;
@@ -82,9 +84,11 @@ function main(input, options) {
     };
 
     finalCustomVocab['@context'][customBaseIri.prefix] = customBaseIri.iri;
-    Object.keys(customPrefixes).forEach(prefix => {
-      finalCustomVocab['@context'][prefix] = customPrefixes[prefix]
-    });
+    if (customPrefixes) {
+      Object.keys(customPrefixes).forEach(prefix => {
+        finalCustomVocab['@context'][prefix] = customPrefixes[prefix]
+      });
+    }
 
     return {shapes: finalShapes, customVocab: finalCustomVocab};
   } else {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function parseMembers(options) {
           customVocab.push({
             '@id': latestCustomVocabElementId,
             '@type': 'Class',
-            'subClassOf': {'@id': 'owl:Thing'}
+            'subClassOf': {'@id': 'schema:Thing'}
           });
       }
     } else if (split[0] === '@superTypes') { // always assumes @type has already been defined
@@ -123,7 +123,7 @@ function parseMembers(options) {
         subClasses.push(split[i]);
       }
         
-      customVocab.pop() // remove previous default subClass definition
+      customVocab.pop() // remove default subClassOf definition
       customVocab.push({
         '@id': latestCustomVocabElementId,
         '@type': 'Class',

--- a/index.js
+++ b/index.js
@@ -108,13 +108,33 @@ function parseMembers(options) {
       shape.targetClass = {'@id': split[1]};
       idToType[id] = split[1];
 
+      // able to define extra classes beyond 'type' to create class hierarchy
+      let subClasses = [];
+      if (split.length > 2) {
+        for(let i = 2, size = split.length; i < size ; i++){
+          subClasses.push(split[i]);
+        }
+      }
+
       if (customBaseIri && split[1].startsWith(customBaseIri.prefix + ':')) {
         latestCustomVocabElementId = split[1];
-        customVocab.push({
-          '@id': latestCustomVocabElementId,
-          '@type': 'Class',
-          'subClassOf': {'@id': 'schema:Thing'}
-        });
+        if (subClasses.length === 0) { // add default subclassOf definition
+          customVocab.push({
+            '@id': latestCustomVocabElementId,
+            '@type': 'Class',
+            'subClassOf': {'@id': 'owl:Thing'}
+          });
+        } else { // add custom subClassOf definitions
+          let scListOfMaps = []
+          subClasses.forEach(sc => {
+            scListOfMaps.push({'@id': sc})
+          })
+          customVocab.push({
+            '@id': latestCustomVocabElementId,
+            '@type': 'Class',
+            'subClassOf': {'@list': scListOfMaps}
+          });
+        }
       }
     } else if (split[0] === '@extraTypes') {
       const types = member.replace('@extraTypes ', '').split(' ');


### PR DESCRIPTION
SubClassOf support:

- In case a class definition starts with a custom base IRI, the @type annotation can be used to list more than one type. Additional types will be added to the custom vocab as a list of superclasses for the respective class. This way, the vocabulary can contain class hierarchies.

Custom Prefixes:

- Add a separate cli option (-p) that allows users to add custom prefixes. The expected format is as follows: 

merweb -p "prefix1=iri1;prefix2=iri2"

- Prefixes are parsed and added to the @context of the shapes and custom vocab. 